### PR TITLE
Bump RD version from 1.0.0 to 1.0.1 - Fix download binaries

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,7 +6,7 @@ googleAnalytics = 'UA-56382716-10'
 
 [params]
   custom_css = ["custom.css"]
-  version = "1.0.0"
+  version = "1.0.1"
 
 [privacy]
   [privacy.googleAnalytics]


### PR DESCRIPTION
Rancher Desktop home page still pointing to old version:
<img width="626" alt="Screen Shot 2022-02-03 at 3 17 09 PM" src="https://user-images.githubusercontent.com/37411123/152404009-0b347935-73fd-4a04-af8d-3c6fc7b5aeb8.png">

