### PR TITLE
Toms updates

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -1,7 +1,7 @@
 ---
-title: "Kubernetes and Container Management on the Desktop"
+title: "Container Management and Kubernetes on the Desktop"
 subtitle: "An open-source desktop application for Mac, Windows and Linux."
-description: Rancher Desktop runs Kubernetes and container management on your desktop. You can choose the version of Kubernetes you want to run. You can build, push, pull, and run container images using either containerd or Moby (dockerd). The container images you build can be run by Kubernetes immediately without the need for a registry.
+description: An open-source desktop application for Mac, Windows and Linux. Rancher Desktop runs Kubernetes and container management on your desktop. You can choose the version of Kubernetes you want to run. You can build, push, pull, and run container images using either containerd or Moby (dockerd). The container images you build can be run by Kubernetes immediately without the need for a registry.
 class: "landing-page"
 pagewidth: 12
 ---

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,19 @@
+{{ define "header" }}
+
+{{ partial "page-header-index.html" . }}
+
+{{ end }}
+
+{{ define "main" }}
+    <div class="main main-raised">
+      <div class="section section-basic">
+        <div class="container">
+          <div class="row">
+            <div class="col-md-{{.Params.pagewidth | default "6"}} ml-auto mr-auto">
+            {{ .Content }}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+{{ end }}

--- a/layouts/partials/page-header-index.html
+++ b/layouts/partials/page-header-index.html
@@ -1,0 +1,19 @@
+<div class="page-header header-filter clear-filter blue-filter" 
+       data-parallax="true" 
+       style="background-image: url('{{ .Site.Params.background | absURL }}');">
+    <div class="container">
+      <div class="row">
+        <div class="col-md-7">
+          <div class="brand">
+            <h1>{{ .Title }}</h1>            
+            {{ with .Params.description }} {{ . }}{{ end }}  
+          </div>
+        </div>
+        <div class="col-md-5">
+          <div class="demo-video">
+            <iframe style="width:100%;" height="315" src="https://www.youtube.com/embed/DKUzfjjuPHI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          </div>
+        </div>
+      </div>
+    </div>
+</div>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -12,7 +12,15 @@ inheritance.
 .navbar.navbar-transparent .navbar-brand,
 .navbar.navbar-transparent .navbar-nav .nav-item .nav-link
 {
-    color: #ffffff;
+    color: rgb(85, 85, 85);
+}
+
+@media (min-width: 992px) {
+    .navbar.navbar-transparent .navbar-brand,
+    .navbar.navbar-transparent .navbar-nav .nav-item .nav-link
+    {
+        color: #ffffff;
+    }
 }
 
 .navbar .navbar-brand,

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -24,3 +24,14 @@ inheritance.
     max-height: .8125rem;
     padding-right: 10px;
 }
+
+.demo-video {
+    margin-top: 20px;
+    display: none;
+}
+
+@media (min-width: 768px) {
+    .demo-video {
+      display: block;
+    }
+  }

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -3,6 +3,23 @@
     margin-top: -5px;
 }
 
+/*
+The colors applied to the nav item are due to a bug in chrome that does not
+redraw the screen correctly when scrolling. This does not happen in Safari or
+Firefox and a change to Chrome introduced the issue. It has to do with 
+inheritance.
+*/
+.navbar.navbar-transparent .navbar-brand,
+.navbar.navbar-transparent .navbar-nav .nav-item .nav-link
+{
+    color: #ffffff;
+}
+
+.navbar .navbar-brand,
+.navbar .navbar-nav .nav-item .nav-link {
+    color: rgb(85, 85, 85);
+}
+
 .nav-item img {
     max-height: .8125rem;
     padding-right: 10px;


### PR DESCRIPTION
Marketing proposed some changes to:

- Fix the navigation links. In chrome they are not displaying properly. This is only in Chrome and not other browsers. A chrome update caused this issue to surface.
- Add a demo video above the fold.

The images below show the new header at different widths. Note, at low widths where the video doesn't fit it is removed.
<img width="1150" alt="Screen Shot 2022-03-11 at 2 20 17 PM" src="https://user-images.githubusercontent.com/62991/157936913-759922ba-a38b-4325-9ed1-fec8f9eddd5c.png">

<img width="1555" alt="Screen Shot 2022-03-11 at 2 20 06 PM" src="https://user-images.githubusercontent.com/62991/157936924-d97de1bb-8949-4e7c-8b41-ae3ea6836a8d.png">

