### PR TITLE
Updated the windows build link to use .msi instead of .exe

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -37,7 +37,7 @@ file_download</span></a></p>
           <div class="col-lg-3 col-md-6">
             <div class="info">
               <img src="/images/logo-windows.svg" height="50" alt="Windows">
-              <p class="mt-4"><a href="https://github.com/rancher-sandbox/rancher-desktop/releases/download/v{{< param version >}}/Rancher.Desktop.Setup.{{< param version >}}.exe">Download Windows <span class="material-icons">
+              <p class="mt-4"><a href="https://github.com/rancher-sandbox/rancher-desktop/releases/download/v{{< param version >}}/Rancher.Desktop.Setup.{{< param version >}}.msi">Download Windows <span class="material-icons">
 file_download</span></a></p>
             </div>
           </div>


### PR DESCRIPTION
Updated the windows build link to use .msi instead of .exe as we introduced .msi in 1.7.0 and would like the MSI to be the default going forward.

Signed-off-by: Gunasekhar Matamalam <gunasekhar.matamalam@suse.com>