### PR TITLE
Updated version variable to 1.8.1

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,7 +6,7 @@ googleAnalytics = 'UA-56382716-10'
 
 [params]
   custom_css = ["custom.css"]
-  version = "1.8.0"
+  version = "1.8.1"
 
 [privacy]
   [privacy.googleAnalytics]


### PR DESCRIPTION
The `version` variable has been updated from `1.8.0` to `1.8.1`.

This impacts the download links.