### PR TITLE
Updating RD Download to 1.9.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -6,7 +6,7 @@ googleAnalytics = 'UA-56382716-10'
 
 [params]
   custom_css = ["custom.css"]
-  version = "1.8.1"
+  version = "1.9.0"
   googleTagManager = "GTM-57KS2MW"
 
 [privacy]


### PR DESCRIPTION
Updating the download links to point to the latest 1.9.0 RD release.